### PR TITLE
Make note to install git on older versions of OS X

### DIFF
--- a/en/deploy/install_git.md
+++ b/en/deploy/install_git.md
@@ -6,6 +6,8 @@ You can download Git from [git-scm.com](https://git-scm.com/). You can hit "next
 
 Download Git from [git-scm.com](https://git-scm.com/) and just follow the instructions.
 
+> **Note** If you are running OS X 10.6, 10.7, or 10.8, you will need to install the version of git from here: [Git installer for OS X Snow Leopard](https://sourceforge.net/projects/git-osx-installer/files/git-2.3.5-intel-universal-snow-leopard.dmg/download)
+
 ### Linux
 
 If it isn't installed already, git should be available via your package manager, so try:


### PR DESCRIPTION
This is a note to make it easier for people using older versions of OS X to install git without a problem. The main installer on git-scm only works on 10.9 (Mavericks) or newer.